### PR TITLE
fix: improve return types and error handling for execution results

### DIFF
--- a/src/asteroid_odyssey/__init__.py
+++ b/src/asteroid_odyssey/__init__.py
@@ -6,8 +6,11 @@ from .client import (
     get_execution_result,
     wait_for_execution_result,
     upload_execution_files,
-    get_browser_session_recording
+    get_browser_session_recording,
+    ExecutionError,
+    TimeoutError
 )
+from .agents_v1_gen import ExecutionResult
 
 __all__ = [
     'AsteroidClient',
@@ -17,5 +20,8 @@ __all__ = [
     'get_execution_result',
     'wait_for_execution_result',
     'upload_execution_files',
-    'get_browser_session_recording'
+    'get_browser_session_recording',
+    'ExecutionError',
+    'TimeoutError',
+    'ExecutionResult'
 ]


### PR DESCRIPTION
- Change return types from Dict[str, Any] to ExecutionResult for better type safety
- Add custom exceptions ExecutionError and TimeoutError for better error handling
- Handle validation errors gracefully when executions are still running